### PR TITLE
Fix verbose output bug

### DIFF
--- a/ConvertTo-STJson.ps1
+++ b/ConvertTo-STJson.ps1
@@ -112,8 +112,8 @@ function ConvertToJsonInternal {
     }
     
     elseif ($InputObject -is [HashTable]) {
-        Write-Verbose -Message "Input object is a hash table (keys: $($Keys -join ', '))."
         $Keys = @($InputObject.Keys)
+        Write-Verbose -Message "Input object is a hash table (keys: $($Keys -join ', '))."
     }
     
     elseif ($InputObject.GetType().FullName -eq "System.Management.Automation.PSCustomObject") {


### PR DESCRIPTION
Hashtable keys were null at the time Write-Verbose tried to write them. Changed the order of two lines. I have really not gotten much feedback (serious feedback) about this cmdlet. I should web search that "output type" thing, so passing through $null, $true and $false preserves type (presumably that's what it allows for).